### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: PHP Compatibility
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: PHPCompatibility
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
@@ -23,7 +23,7 @@ jobs:
       max-parallel: 3
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Updates GitHub Actions to node24 runtime-compatible versions:

- **actions/checkout**: v2/v3 → v6.0.3

Added github-actions Dependabot config to keep actions current.

🤖